### PR TITLE
Distinguish dependency type, security fixes and add config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ automerged_updates:
     #   SemVer minor update, e.g. > 1.x && 2.1.4 to 2.3.1
     # - "in_range" (NOT SUPPORTED YET)
     #   matching the version requirement in your package manifest
+    # - "security:all"
     # - "all"
     # To allow prereleases, the corresponding prepatch, preminor and premajor types are also supported
 - match:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ automerged_updates:
     # - "in_range" (NOT SUPPORTED YET)
     #   matching the version requirement in your package manifest
     # - "all"
+    # To allow prereleases, the corresponding prepatch, preminor and premajor types are also supported
 - match:
     dependency_type: "production"
     update_type: "security:minor" # includes patch updates!

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Using the configuration file `.github/auto-merge.yml`, you have the option to pr
 * minor security-critical production dependency updates
 
 ```yml
-automerged_updates:
 - match:
     dependency_type: "development"
     # Supported dependency types:

--- a/README.md
+++ b/README.md
@@ -85,3 +85,40 @@ steps:
 | `github-token` | ❌       | `github.token` | The GitHub token used to merge the pull-request     |
 | `command`      | ❌       | `merge`        | The command to pass to Dependabot                   |
 | `approve`      | ❌       | `true`         | Auto-approve pull-requests                          |
+
+### Configuration file syntax
+
+Using the configuration file `.github/auto-merge.yml`, you have the option to provide a more fine-grained configuration. The following example configuration file merges
+
+* minor development dependency updates
+* patch production dependency updates
+* minor security-critical production dependency updates
+
+```yml
+automerged_updates:
+- match:
+    dependency_type: "development"
+    # Supported dependency types:
+    # - "development"
+    # - "production"
+    # - "all"
+    update_type: "semver:minor" # includes patch updates!
+    # Supported updates to automerge:
+    # - "security:patch"
+    #   SemVer patch update that fixes a known security vulnerability
+    # - "semver:patch"
+    #   SemVer patch update, e.g. > 1.x && 1.0.1 to 1.0.3
+    # - "semver:minor"
+    #   SemVer minor update, e.g. > 1.x && 2.1.4 to 2.3.1
+    # - "in_range" (NOT SUPPORTED YET)
+    #   matching the version requirement in your package manifest
+    # - "all"
+- match:
+    dependency_type: "production"
+    update_type: "security:minor" # includes patch updates!
+- match:
+    dependency_type: "production"
+    update_type: "semver:patch"
+```
+
+The syntax is based on https://dependabot.com/docs/config-file/#automerged_updates, but does not support `dependency_name` and `in_range` yet.

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,10 @@ inputs:
     default: true
 
   target:
-    description: The version comparison target (major, minor, patch)
+    description: The version comparison target (major, minor, patch). This is ignored if .github/auto-merge.yml exists
     default: patch
     required: false
 
 runs:
   using: docker
-  image: docker://ahmadnassri/action-dependabot-auto-merge:v1
+  image: Dockerfile

--- a/action/index.js
+++ b/action/index.js
@@ -10,7 +10,7 @@ import main from './lib/index.js'
 // parse inputs
 const inputs = {
   token: core.getInput('github-token', { required: true }),
-  target: core.getInput('target', { required: true }),
+  target: core.getInput('target', { required: false }),
   command: core.getInput('command', { required: false }),
   approve: core.getInput('approve', { required: false })
 }

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -25,7 +25,11 @@ export default async function (inputs) {
   const octokit = github.getOctokit(inputs.token)
 
   // parse and determine what command to tell dependabot
-  const proceed = parse(pull_request.title, inputs.target || 'patch')
+  const proceed = parse(
+    pull_request.title,
+    pull_request.labels.map(l => l.name),
+    inputs.target
+  )
 
   if (proceed) {
     const command = inputs.approve === 'true' ? approve : comment

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -27,7 +27,7 @@ export default async function (inputs) {
   // parse and determine what command to tell dependabot
   const proceed = parse(
     pull_request.title,
-    pull_request.labels.map(l => l.name),
+    pull_request.labels.map(l => l.name.toLowerCase()),
     inputs.target
   )
 

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -10,7 +10,6 @@ const semverRegEx = /(?<version>(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<p
 const depNameRegex = /(?<name>(?:@[^\s]+\/)?[^\s]+) from/
 // regexes to detect dependency type from PR title
 const devDependencyRegEx = /\((deps-dev)\):/
-const dependencyRegEx = /\((deps)\):/
 const securityRegEx = /(^|: )\[Security\]/i
 
 const ghWorkspace = process.env.GITHUB_WORKSPACE || "/github/workspace";

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -16,6 +16,7 @@ const securityRegEx = /(^|: )\[Security\]/i
 const ghWorkspace = process.env.GITHUB_WORKSPACE || "/github/workspace";
 
 const weight = {
+  all: 1000,
   premajor: 6,
   major: 5,
   preminor: 4,
@@ -112,7 +113,6 @@ export default function (title, labels = [], target) {
       } else if (update_type.includes(":")) {
         // security:patch, semver:minor, ...
         const [secOrSemver, maxType] = update_type.split(":", 2);
-        console.log(maxType);
         if (secOrSemver === "security" && !isSecurity) continue;
         if ((weight[maxType] || 0) >= (weight[updateType] || 0)) {
           // tell dependabot to merge

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -16,8 +16,12 @@ const securityRegEx = /(^|: )\[Security\]/i
 const ghWorkspace = process.env.GITHUB_WORKSPACE || "/github/workspace";
 
 const weight = {
-  major: 3,
-  minor: 2,
+  premajor: 6,
+  major: 5,
+  preminor: 4,
+  minor: 3,
+  prepatch: 2,
+  prerelease: 2, // equal to prepatch
   patch: 1
 }
 

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -1,8 +1,17 @@
 import semver from 'semver'
 import core from '@actions/core'
+import path from 'path'
+import fs from 'fs'
+import yaml from 'js-yaml';
 
 // semver regex
 const semverRegEx = /(?<version>(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/
+// regex to detect dependency name
+const depNameRegex = /((?:@[^\s]+\/)?[^\s]+) from/
+// regexes to detect dependency type from PR title
+const devDependencyRegEx = /\((deps-dev)\):/
+const dependencyRegEx = /\((deps)\):/
+const securityRegEx = /(^|: )\[Security\]/i
 
 const weight = {
   major: 3,
@@ -10,9 +19,19 @@ const weight = {
   patch: 1
 }
 
-export default function (title, target) {
+export default function (title, labels, target) {
   // log
   core.info(`title: "${title}"`)
+
+  // extract dep name from the title
+  const depName = title.match(depNameRegex)?.[1];
+  core.info(`depName: ${depName}`)
+
+  // exit early
+  if (!depName) {
+    core.error('failed to parse title: could not detect dependency name')
+    return process.exit(0) // soft exit
+  }
 
   // extract version from the title
   const from = title.match(new RegExp('from ' + semverRegEx.source))?.groups
@@ -24,18 +43,78 @@ export default function (title, target) {
     return process.exit(0) // soft exit
   }
 
+  let isDev = devDependencyRegEx.test(title);
+  let isProd = dependencyRegEx.test(title);
+  const isSecurity = securityRegEx.test(title) || labels.includes("security") || labels.includes("Security");
+
+  if (!isDev && !isProd) {
+    // couldn't extract the dependency type from the title, try to read package.json
+    try {
+      const packageJsonPath = path.join(process.env.GITHUB_WORKSPACE, 'package.json')
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      isDev = depName in packageJson.devDependencies
+      isProd = depName in packageJson.dependencies
+    } catch (e) {
+      console.dir(e);
+     }
+  }
+  if (!isDev && !isProd) {
+    // we failed again, assume its a production dependency
+    core.info(`failed to parse dependency type, assuming it is a production dependency`)
+    isProd = true
+  }
+
   // log
   core.info(`from: ${from.version}`)
   core.info(`to: ${to.version}`)
+  core.info(`dependency type: ${isDev ? "development" : isProd ? "production" : "unknown"}`)
+  core.info(`security critical: ${isSecurity}`)
+
+  // convert target to the automerged_updates syntax
+  const configPath = path.join(process.env.GITHUB_WORKSPACE, '.github/auto-merge.yml')
+  let mergeConfig;
+  if (fs.existsSync(configPath)) {
+    // parse .github/auto-merge.yml
+    mergeConfig = yaml.safeLoad(fs.readFileSync(configPath, 'utf8'));
+    core.info('loaded merge config: ' + JSON.stringify(mergeConfig, undefined, 4));
+  } else {
+    mergeConfig = {
+      automerged_updates: [
+        { match: { dependency_type: "all", update_type: `semver:${target}` } },
+      ],
+    };
+    core.info('target converted to equivalent config: ' + JSON.stringify(mergeConfig, undefined, 4));
+  }
 
   // analyze with semver
-  const result = semver.diff(from.version, to.version)
+  const updateType = semver.diff(from.version, to.version)
 
-  // compare weight to target
-  if ((weight[target] || 0) >= (weight[result] || 0)) {
-    // tell dependabot to merge
-    core.info(`dependency update target is "${target}", found "${result}", will auto-merge`)
-    return true
+  // Check all defined automerge configs to see if one matches
+  for (const {
+    match: { dependency_type, update_type },
+  } of mergeConfig.automerged_updates) {
+    if (
+      dependency_type === "all" ||
+      (dependency_type === "production" && isProd) ||
+      (dependency_type === "development" && isDev)
+    ) {
+      if (update_type === "all") {
+        core.info(`all ${dependency_type} updates allowed, will auto-merge`);
+        return true;
+      } else if (update_type === "in_range") {
+        throw new Error("in_range update type not supported yet");
+      } else if (update_type.includes(":")) {
+        // security:patch, semver:minor, ...
+        const [secOrSemver, maxType] = update_type.split(":", 2);
+        console.log(maxType);
+        if (secOrSemver === "security" && !isSecurity) continue;
+        if ((weight[maxType] || 0) >= (weight[updateType] || 0)) {
+          // tell dependabot to merge
+          core.info(`${dependency_type} dependency update ${update_type} allowed, got ${isSecurity ? "security" : "semver"}:${updateType}, will auto-merge`);
+          return true;
+        }
+      }
+    }
   }
 
   core.info('manual merging required')

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -58,8 +58,8 @@ export default function (title, labels = [], target) {
     try {
       const packageJsonPath = path.join(ghWorkspace, 'package.json')
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-      isDev = depName in packageJson.devDependencies
-      isProd = depName in packageJson.dependencies
+      isDev = !!packageJson.devDependencies && depName in packageJson.devDependencies
+      isProd = !!packageJson.dependencies && depName in packageJson.dependencies
     } catch (e) {
       console.dir(e);
      }

--- a/action/lib/shared.js
+++ b/action/lib/shared.js
@@ -1,0 +1,7 @@
+export const ghWorkspace = process.env.GITHUB_WORKSPACE || "/github/workspace";
+
+export function targetToMergeConfig(target) {
+  return [
+    { match: { dependency_type: "all", update_type: `semver:${target}` } },
+  ]
+}

--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -350,7 +350,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -772,8 +771,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "events-to-array": {
       "version": "1.1.2",
@@ -1262,7 +1260,6 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
       "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2066,8 +2063,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/action/package.json
+++ b/action/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@actions/core": "^1.2.4",
     "@actions/github": "^4.0.0",
+    "js-yaml": "^3.14.0",
     "semver": "^7.3.2"
   },
   "devDependencies": {

--- a/action/test/parse/config-file.js
+++ b/action/test/parse/config-file.js
@@ -116,12 +116,14 @@ const tests = [
   },
 ];
 
+const mergeConfigExistsPackageJsonDoesNot = path => !path.endsWith("package.json");
+
 for (const test of tests) {
   tap.test(`compound merge configs in config files --> ${test.name}`, async assert => {
     sinon.stub(core, 'info')
     // Ensure .github/auto-merge.yml exists in tests
     sinon.stub(fs, 'readFileSync').returns(test.config)
-    sinon.stub(fs, 'existsSync').returns(true)
+    sinon.stub(fs, 'existsSync').callsFake(mergeConfigExistsPackageJsonDoesNot)
 
     if (test.throws === true) {
       assert.throws(() => parse(test.title));

--- a/action/test/parse/config-file.js
+++ b/action/test/parse/config-file.js
@@ -3,7 +3,7 @@ import tap from 'tap'
 
 import sinon from 'sinon'
 import core from '@actions/core'
-import fs from 'fs'
+import yaml from 'js-yaml';
 
 // module
 import parse from '../../lib/parse.js'
@@ -116,23 +116,18 @@ const tests = [
   },
 ];
 
-const mergeConfigExistsPackageJsonDoesNot = path => !path.endsWith("package.json");
-
 for (const test of tests) {
   tap.test(`compound merge configs in config files --> ${test.name}`, async assert => {
     sinon.stub(core, 'info')
-    // Ensure .github/auto-merge.yml exists in tests
-    sinon.stub(fs, 'readFileSync').returns(test.config)
-    sinon.stub(fs, 'existsSync').callsFake(mergeConfigExistsPackageJsonDoesNot)
+
+    const mergeConfig = yaml.safeLoad(test.config);
 
     if (test.throws === true) {
-      assert.throws(() => parse(test.title));
+      assert.throws(() => parse(test.title, [], mergeConfig));
     } else {
-      assert.equal(parse(test.title), test.expect);
+      assert.equal(parse(test.title, [], mergeConfig), test.expect);
     }
 
     core.info.restore()
-    fs.readFileSync.restore()
-    fs.existsSync.restore()
   });
 }

--- a/action/test/parse/config-file.js
+++ b/action/test/parse/config-file.js
@@ -9,7 +9,6 @@ import fs from 'fs'
 import parse from '../../lib/parse.js'
 
 const configAllPatchSecMinor = `
-automerged_updates:
 - match:
     dependency_type: "all"
     update_type: "semver:patch"
@@ -19,7 +18,6 @@ automerged_updates:
 `
 
 const configAllPatchDevSecAll = `
-automerged_updates:
 - match:
     dependency_type: "all"
     update_type: "semver:patch"
@@ -29,7 +27,6 @@ automerged_updates:
 `
 
 const configProdPatchDevMajor = `
-automerged_updates:
 - match:
     dependency_type: "production"
     update_type: "semver:patch"
@@ -39,7 +36,6 @@ automerged_updates:
 `
 
 const configInRange = `
-automerged_updates:
 - match:
     dependency_type: "all"
     update_type: "in_range"

--- a/action/test/parse/config-file.js
+++ b/action/test/parse/config-file.js
@@ -1,0 +1,140 @@
+// packages
+import tap from 'tap'
+
+import sinon from 'sinon'
+import core from '@actions/core'
+import fs from 'fs'
+
+// module
+import parse from '../../lib/parse.js'
+
+const configAllPatchSecMinor = `
+automerged_updates:
+- match:
+    dependency_type: "all"
+    update_type: "semver:patch"
+- match:
+    dependency_type: "all"
+    update_type: "security:minor"
+`
+
+const configAllPatchDevSecAll = `
+automerged_updates:
+- match:
+    dependency_type: "all"
+    update_type: "semver:patch"
+- match:
+    dependency_type: "development"
+    update_type: "security:all"
+`
+
+const configProdPatchDevMajor = `
+automerged_updates:
+- match:
+    dependency_type: "production"
+    update_type: "semver:patch"
+- match:
+    dependency_type: "development"
+    update_type: "semver:major"
+`
+
+const configInRange = `
+automerged_updates:
+- match:
+    dependency_type: "all"
+    update_type: "in_range"
+`
+
+const tests = [
+  {
+    name: "all deps patch, security minor --> patch (✓)",
+    expect: true,
+    config: configAllPatchSecMinor,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.1.4'
+  },
+  {
+    name: "all deps patch, security minor --> minor (✗)",
+    expect: false,
+    config: configAllPatchSecMinor,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.2.0'
+  },
+  {
+    name: "all deps patch, security minor --> security:minor (✓)",
+    expect: true,
+    config: configAllPatchSecMinor,
+    title: 'chore(deps): [security] bump api-problem from 6.1.2 to 6.2.0'
+  },
+  {
+    name: "all deps patch, security minor --> security:major (✗)",
+    expect: false,
+    config: configAllPatchSecMinor,
+    title: 'chore(deps): [security] bump api-problem from 6.1.2 to 7.2.0'
+  },
+  {
+    name: "all deps patch, dev security all --> patch (✓)",
+    expect: true,
+    config: configAllPatchDevSecAll,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.1.3'
+  },
+  {
+    name: "all deps patch, dev security all --> preminor (✗)",
+    expect: false,
+    config: configAllPatchDevSecAll,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.2.0-pre'
+  },
+  {
+    name: "all deps patch, dev security all --> dev security:premajor (✓)",
+    expect: true,
+    config: configAllPatchDevSecAll,
+    title: 'chore(deps-dev): [security] bump api-problem from 6.1.2 to 7.0.0-pre'
+  },
+  {
+    name: "prod patch, dev major --> prod patch (✓)",
+    expect: true,
+    config: configProdPatchDevMajor,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.1.3'
+  },
+  {
+    name: "prod patch, dev major --> prod minor (✗)",
+    expect: false,
+    config: configProdPatchDevMajor,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.2.0'
+  },
+  {
+    name: "prod patch, dev major --> dev minor (✓)",
+    expect: true,
+    config: configProdPatchDevMajor,
+    title: 'chore(deps-dev): bump api-problem from 6.1.2 to 6.2.0'
+  },
+  {
+    name: "prod patch, dev major --> dev premajor (✗)",
+    expect: false,
+    config: configProdPatchDevMajor,
+    title: 'chore(deps-dev): bump api-problem from 6.1.2 to 7.0.0-pre'
+  },
+  {
+    name: "in_range --> throws",
+    throws: true,
+    config: configInRange,
+    title: 'chore(deps): bump api-problem from 6.1.2 to 6.1.3'
+  },
+];
+
+for (const test of tests) {
+  tap.test(`compound merge configs in config files --> ${test.name}`, async assert => {
+    sinon.stub(core, 'info')
+    // Ensure .github/auto-merge.yml exists in tests
+    sinon.stub(fs, 'readFileSync').returns(test.config)
+    sinon.stub(fs, 'existsSync').returns(true)
+
+    if (test.throws === true) {
+      assert.throws(() => parse(test.title));
+    } else {
+      assert.equal(parse(test.title), test.expect);
+    }
+
+    core.info.restore()
+    fs.readFileSync.restore()
+    fs.existsSync.restore()
+  });
+}

--- a/action/test/parse/dependency-types.js
+++ b/action/test/parse/dependency-types.js
@@ -17,21 +17,24 @@ const fakePackageJsonDev = JSON.stringify({
     "api-problem": "6.1.2",
   }
 });
+const packageJsonExistsMergeConfigDoesNot = path => path.endsWith("package.json");
 
 tap.test('title -> security tag is detected', async assert => {
   assert.plan(3)
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
 
   const proceed = parse('[Security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(5).args[0], 'security critical: true')
+  assert.equal(core.info.getCall(6).args[0], 'security critical: true')
 
   core.info.restore()
   fs.readFileSync.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('title -> security tag is detected (conventional commits)', async assert => {
@@ -39,15 +42,17 @@ tap.test('title -> security tag is detected (conventional commits)', async asser
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
 
   const proceed = parse('chore(deps): [security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(5).args[0], 'security critical: true')
+  assert.equal(core.info.getCall(6).args[0], 'security critical: true')
 
   core.info.restore()
   fs.readFileSync.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('labels -> security tag is detected', async assert => {
@@ -55,15 +60,17 @@ tap.test('labels -> security tag is detected', async assert => {
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
 
   const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', ['security'], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(5).args[0], 'security critical: true')
+  assert.equal(core.info.getCall(6).args[0], 'security critical: true')
 
   core.info.restore()
   fs.readFileSync.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('labels -> not security-critical update is detected', async assert => {
@@ -71,21 +78,24 @@ tap.test('labels -> not security-critical update is detected', async assert => {
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
 
   const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(5).args[0], 'security critical: false')
+  assert.equal(core.info.getCall(6).args[0], 'security critical: false')
 
   core.info.restore()
   fs.readFileSync.restore()
+  fs.existsSync.restore()
 })
 
-tap.test('title -> dependency is detected as dev dependency', async assert => {
+tap.test('title -> dependency is detected as dev dependency (title fallback)', async assert => {
   assert.plan(3)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps-dev): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
@@ -94,27 +104,31 @@ tap.test('title -> dependency is detected as dev dependency', async assert => {
   assert.equal(core.info.getCall(4).args[0], 'dependency type: development')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
-tap.test('title -> dependency is detected as production dependency', async assert => {
+tap.test('title -> dependency is detected as production dependency (title fallback)', async assert => {
   assert.plan(3)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(4).args[0], 'dependency type: production')
+  assert.equal(core.info.getCall(5).args[0], 'dependency type: production')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
-tap.test('title -> dependency is detected as dev dependency (package.json fallback)', async assert => {
+tap.test('title -> dependency is detected as dev dependency (package.json)', async assert => {
   assert.plan(3)
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJsonDev)
+  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
 
   const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
@@ -124,20 +138,23 @@ tap.test('title -> dependency is detected as dev dependency (package.json fallba
 
   core.info.restore()
   fs.readFileSync.restore()
+  fs.existsSync.restore()
 })
 
-tap.test('title -> dependency is detected as production dependency (package.json fallback)', async assert => {
+tap.test('title -> dependency is detected as production dependency (package.json)', async assert => {
   assert.plan(3)
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
 
   const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(4).args[0], 'dependency type: production')
+  assert.equal(core.info.getCall(5).args[0], 'dependency type: production')
 
   core.info.restore()
   fs.readFileSync.restore()
+  fs.existsSync.restore()
 })

--- a/action/test/parse/dependency-types.js
+++ b/action/test/parse/dependency-types.js
@@ -1,0 +1,143 @@
+// packages
+import tap from 'tap'
+import sinon from 'sinon'
+import core from '@actions/core'
+import fs from 'fs'
+
+// module
+import parse from '../../lib/parse.js'
+
+const fakePackageJson = JSON.stringify({
+  dependencies: {
+    "api-problem": "6.1.2",
+  }
+});
+const fakePackageJsonDev = JSON.stringify({
+  devDependencies: {
+    "api-problem": "6.1.2",
+  }
+});
+
+tap.test('title -> security tag is detected', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+
+  const proceed = parse('[Security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(5).args[0], 'security critical: true')
+
+  core.info.restore()
+  fs.readFileSync.restore()
+})
+
+tap.test('title -> security tag is detected (conventional commits)', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+
+  const proceed = parse('chore(deps): [security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(5).args[0], 'security critical: true')
+
+  core.info.restore()
+  fs.readFileSync.restore()
+})
+
+tap.test('labels -> security tag is detected', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', ['security'], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(5).args[0], 'security critical: true')
+
+  core.info.restore()
+  fs.readFileSync.restore()
+})
+
+tap.test('labels -> not security-critical update is detected', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(5).args[0], 'security critical: false')
+
+  core.info.restore()
+  fs.readFileSync.restore()
+})
+
+tap.test('title -> dependency is detected as dev dependency', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+
+  const proceed = parse('chore(deps-dev): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(4).args[0], 'dependency type: development')
+
+  core.info.restore()
+})
+
+tap.test('title -> dependency is detected as production dependency', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(4).args[0], 'dependency type: production')
+
+  core.info.restore()
+})
+
+tap.test('title -> dependency is detected as dev dependency (package.json fallback)', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'readFileSync').returns(fakePackageJsonDev)
+
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(4).args[0], 'dependency type: development')
+
+  core.info.restore()
+  fs.readFileSync.restore()
+})
+
+tap.test('title -> dependency is detected as production dependency (package.json fallback)', async assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
+
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+
+  assert.ok(proceed)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(4).args[0], 'dependency type: production')
+
+  core.info.restore()
+  fs.readFileSync.restore()
+})

--- a/action/test/parse/dependency-types.js
+++ b/action/test/parse/dependency-types.js
@@ -6,6 +6,7 @@ import fs from 'fs'
 
 // module
 import parse from '../../lib/parse.js'
+import { targetToMergeConfig } from '../../lib/shared.js'
 
 const fakePackageJson = JSON.stringify({
   dependencies: {
@@ -17,16 +18,15 @@ const fakePackageJsonDev = JSON.stringify({
     "api-problem": "6.1.2",
   }
 });
-const packageJsonExistsMergeConfigDoesNot = path => path.endsWith("package.json");
 
 tap.test('title -> security tag is detected', async assert => {
   assert.plan(3)
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
-  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
+  sinon.stub(fs, 'existsSync').returns(true)
 
-  const proceed = parse('[Security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('[Security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -42,9 +42,9 @@ tap.test('title -> security tag is detected (conventional commits)', async asser
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
-  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
+  sinon.stub(fs, 'existsSync').returns(true)
 
-  const proceed = parse('chore(deps): [security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('chore(deps): [security] bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -60,9 +60,9 @@ tap.test('labels -> security tag is detected', async assert => {
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
-  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
+  sinon.stub(fs, 'existsSync').returns(true)
 
-  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', ['security'], 'major')
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', ['security'], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -78,9 +78,9 @@ tap.test('labels -> not security-critical update is detected', async assert => {
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
-  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
+  sinon.stub(fs, 'existsSync').returns(true)
 
-  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -97,7 +97,7 @@ tap.test('title -> dependency is detected as dev dependency (title fallback)', a
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps-dev): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('chore(deps-dev): bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -113,7 +113,7 @@ tap.test('title -> dependency is detected as production dependency (title fallba
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -128,9 +128,9 @@ tap.test('title -> dependency is detected as dev dependency (package.json)', asy
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJsonDev)
-  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
+  sinon.stub(fs, 'existsSync').returns(true)
 
-  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -146,9 +146,9 @@ tap.test('title -> dependency is detected as production dependency (package.json
 
   sinon.stub(core, 'info')
   sinon.stub(fs, 'readFileSync').returns(fakePackageJson)
-  sinon.stub(fs, 'existsSync').callsFake(packageJsonExistsMergeConfigDoesNot)
+  sinon.stub(fs, 'existsSync').returns(true)
 
-  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('Bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)

--- a/action/test/parse/invalid-title.js
+++ b/action/test/parse/invalid-title.js
@@ -20,5 +20,24 @@ tap.test('parse -> invalid semver', assert => {
   assert.equal(core.error.getCall(0).args[0], 'failed to parse title: invalid semver')
 
   process.exit.restore()
+  core.info.restore()
+  core.error.restore()
+})
+
+tap.only('parse -> invalid dependency name', assert => {
+  assert.plan(3)
+
+  sinon.stub(core, 'info') // silence output on terminal
+  sinon.stub(core, 'error')
+  sinon.stub(process, 'exit')
+
+  parse('from 1.0.0 to 1.0.1')
+
+  assert.ok(process.exit.called)
+  assert.equal(process.exit.getCall(0).args[0], 0)
+  assert.equal(core.error.getCall(0).args[0], 'failed to parse title: could not detect dependency name')
+
+  process.exit.restore()
+  core.info.restore()
   core.error.restore()
 })

--- a/action/test/parse/match-target.js
+++ b/action/test/parse/match-target.js
@@ -6,6 +6,7 @@ import fs from 'fs'
 
 // module
 import parse from '../../lib/parse.js'
+import { targetToMergeConfig } from '../../lib/shared.js'
 
 tap.test('title -> in range', async assert => {
   assert.plan(7)
@@ -13,7 +14,7 @@ tap.test('title -> in range', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
@@ -21,7 +22,7 @@ tap.test('title -> in range', async assert => {
   assert.equal(core.info.getCall(1).args[0], 'depName: api-problem')
   assert.equal(core.info.getCall(3).args[0], 'from: 6.1.2')
   assert.equal(core.info.getCall(4).args[0], 'to: 6.1.4')
-  assert.equal(core.info.getCall(8).args[0], 'all dependency updates semver:major allowed, got semver:patch, will auto-merge')
+  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:major allowed, got semver:patch, will auto-merge')
 
   core.info.restore()
   fs.existsSync.restore()
@@ -33,13 +34,13 @@ tap.test('parse -> out of range', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0 in /path', [], 'patch')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0 in /path', [], targetToMergeConfig('patch'))
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(3).args[0], 'from: 6.1.2')
   assert.equal(core.info.getCall(4).args[0], 'to: 7.0.0')
-  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
 
   core.info.restore()
   fs.existsSync.restore()

--- a/action/test/parse/match-target.js
+++ b/action/test/parse/match-target.js
@@ -7,18 +7,19 @@ import core from '@actions/core'
 import parse from '../../lib/parse.js'
 
 tap.test('title -> in range', async assert => {
-  assert.plan(6)
+  assert.plan(7)
 
   sinon.stub(core, 'info')
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', 'major')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(0).args[0], 'title: "chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path"')
-  assert.equal(core.info.getCall(1).args[0], 'from: 6.1.2')
-  assert.equal(core.info.getCall(2).args[0], 'to: 6.1.4')
-  assert.equal(core.info.getCall(3).args[0], 'dependency update target is "major", found "patch", will auto-merge')
+  assert.equal(core.info.getCall(1).args[0], 'depName: api-problem')
+  assert.equal(core.info.getCall(2).args[0], 'from: 6.1.2')
+  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.4')
+  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:major allowed, got semver:patch, will auto-merge')
 
   core.info.restore()
 })
@@ -28,13 +29,13 @@ tap.test('parse -> out of range', async assert => {
 
   sinon.stub(core, 'info')
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0 in /path', 'patch')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0 in /path', [], 'patch')
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(1).args[0], 'from: 6.1.2')
-  assert.equal(core.info.getCall(2).args[0], 'to: 7.0.0')
-  assert.equal(core.info.getCall(3).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(2).args[0], 'from: 6.1.2')
+  assert.equal(core.info.getCall(3).args[0], 'to: 7.0.0')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
 
   core.info.restore()
 })

--- a/action/test/parse/match-target.js
+++ b/action/test/parse/match-target.js
@@ -2,6 +2,7 @@
 import tap from 'tap'
 import sinon from 'sinon'
 import core from '@actions/core'
+import fs from 'fs'
 
 // module
 import parse from '../../lib/parse.js'
@@ -10,6 +11,7 @@ tap.test('title -> in range', async assert => {
   assert.plan(7)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path', [], 'major')
 
@@ -17,25 +19,28 @@ tap.test('title -> in range', async assert => {
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(0).args[0], 'title: "chore(deps): bump api-problem from 6.1.2 to 6.1.4 in /path"')
   assert.equal(core.info.getCall(1).args[0], 'depName: api-problem')
-  assert.equal(core.info.getCall(2).args[0], 'from: 6.1.2')
-  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.4')
-  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:major allowed, got semver:patch, will auto-merge')
+  assert.equal(core.info.getCall(3).args[0], 'from: 6.1.2')
+  assert.equal(core.info.getCall(4).args[0], 'to: 6.1.4')
+  assert.equal(core.info.getCall(8).args[0], 'all dependency updates semver:major allowed, got semver:patch, will auto-merge')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('parse -> out of range', async assert => {
   assert.plan(5)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0 in /path', [], 'patch')
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(2).args[0], 'from: 6.1.2')
-  assert.equal(core.info.getCall(3).args[0], 'to: 7.0.0')
-  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(3).args[0], 'from: 6.1.2')
+  assert.equal(core.info.getCall(4).args[0], 'to: 7.0.0')
+  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
 
   core.info.restore()
+  fs.existsSync.restore()
 })

--- a/action/test/parse/pre-release.js
+++ b/action/test/parse/pre-release.js
@@ -6,6 +6,7 @@ import fs from 'fs'
 
 // module
 import parse from '../../lib/parse.js'
+import { targetToMergeConfig } from '../../lib/shared.js'
 
 tap.test('parse -> pre-release -> direct match', async assert => {
   assert.plan(4)
@@ -13,12 +14,12 @@ tap.test('parse -> pre-release -> direct match', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], 'preminor')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], targetToMergeConfig('preminor'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(4).args[0], 'to: 6.1.4-prerelease')
-  assert.equal(core.info.getCall(8).args[0], 'all dependency updates semver:preminor allowed, got semver:prepatch, will auto-merge')
+  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:preminor allowed, got semver:prepatch, will auto-merge')
 
   core.info.restore()
   fs.existsSync.restore()
@@ -30,12 +31,12 @@ tap.test('parse -> pre-release -> greater match', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], 'major')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], targetToMergeConfig('major'))
 
   assert.ok(proceed)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(4).args[0], 'to: 6.1.4-prerelease')
-  assert.equal(core.info.getCall(8).args[0], 'all dependency updates semver:major allowed, got semver:prepatch, will auto-merge')
+  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:major allowed, got semver:prepatch, will auto-merge')
 
   core.info.restore()
   fs.existsSync.restore()
@@ -47,12 +48,12 @@ tap.test('parse -> pre-release -> lesser match (premajor)', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0-pre.0 in /path', [], 'minor')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0-pre.0 in /path', [], targetToMergeConfig('minor'))
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(4).args[0], 'to: 7.0.0-pre.0')
-  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
 
   core.info.restore()
   fs.existsSync.restore()
@@ -64,12 +65,12 @@ tap.test('parse -> pre-release -> lesser match (preminor)', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.2.0-pre.1 in /path', [], 'patch')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.2.0-pre.1 in /path', [], targetToMergeConfig('patch'))
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(4).args[0], 'to: 6.2.0-pre.1')
-  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
 
   core.info.restore()
   fs.existsSync.restore()
@@ -81,12 +82,12 @@ tap.test('parse -> pre-release -> actual prerelease', async assert => {
   sinon.stub(core, 'info')
   sinon.stub(fs, 'existsSync').returns(false)
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2-pre.0 to 6.1.2-pre.1 in /path', [], 'patch')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2-pre.0 to 6.1.2-pre.1 in /path', [], targetToMergeConfig('patch'))
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
   assert.equal(core.info.getCall(4).args[0], 'to: 6.1.2-pre.1')
-  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
 
   core.info.restore()
   fs.existsSync.restore()

--- a/action/test/parse/pre-release.js
+++ b/action/test/parse/pre-release.js
@@ -2,6 +2,7 @@
 import tap from 'tap'
 import sinon from 'sinon'
 import core from '@actions/core'
+import fs from 'fs'
 
 // module
 import parse from '../../lib/parse.js'
@@ -10,73 +11,83 @@ tap.test('parse -> pre-release -> direct match', async assert => {
   assert.plan(4)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], 'preminor')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.4-prerelease')
-  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:preminor allowed, got semver:prepatch, will auto-merge')
+  assert.equal(core.info.getCall(4).args[0], 'to: 6.1.4-prerelease')
+  assert.equal(core.info.getCall(8).args[0], 'all dependency updates semver:preminor allowed, got semver:prepatch, will auto-merge')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('parse -> pre-release -> greater match', async assert => {
   assert.plan(4)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.4-prerelease')
-  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:major allowed, got semver:prepatch, will auto-merge')
+  assert.equal(core.info.getCall(4).args[0], 'to: 6.1.4-prerelease')
+  assert.equal(core.info.getCall(8).args[0], 'all dependency updates semver:major allowed, got semver:prepatch, will auto-merge')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('parse -> pre-release -> lesser match (premajor)', async assert => {
   assert.plan(4)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0-pre.0 in /path', [], 'minor')
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(3).args[0], 'to: 7.0.0-pre.0')
-  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(4).args[0], 'to: 7.0.0-pre.0')
+  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('parse -> pre-release -> lesser match (preminor)', async assert => {
   assert.plan(4)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.2.0-pre.1 in /path', [], 'patch')
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(3).args[0], 'to: 6.2.0-pre.1')
-  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(4).args[0], 'to: 6.2.0-pre.1')
+  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
 
   core.info.restore()
+  fs.existsSync.restore()
 })
 
 tap.test('parse -> pre-release -> actual prerelease', async assert => {
   assert.plan(4)
 
   sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
 
   const proceed = parse('chore(deps): bump api-problem from 6.1.2-pre.0 to 6.1.2-pre.1 in /path', [], 'patch')
 
   assert.notOk(proceed, false)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.2-pre.1')
-  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+  assert.equal(core.info.getCall(4).args[0], 'to: 6.1.2-pre.1')
+  assert.equal(core.info.getCall(8).args[0], 'manual merging required')
 
   core.info.restore()
+  fs.existsSync.restore()
 })

--- a/action/test/parse/pre-release.js
+++ b/action/test/parse/pre-release.js
@@ -11,12 +11,12 @@ tap.test('parse -> pre-release -> direct match', async assert => {
 
   sinon.stub(core, 'info')
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', 'preminor')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], 'preminor')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(2).args[0], 'to: 6.1.4-prerelease')
-  assert.equal(core.info.getCall(3).args[0], 'dependency update target is "preminor", found "prepatch", will auto-merge')
+  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.4-prerelease')
+  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:preminor allowed, got semver:prepatch, will auto-merge')
 
   core.info.restore()
 })
@@ -26,12 +26,12 @@ tap.test('parse -> pre-release -> greater match', async assert => {
 
   sinon.stub(core, 'info')
 
-  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', 'major')
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.1.4-prerelease in /path', [], 'major')
 
   assert.ok(proceed)
   assert.ok(core.info.called)
-  assert.equal(core.info.getCall(2).args[0], 'to: 6.1.4-prerelease')
-  assert.equal(core.info.getCall(3).args[0], 'dependency update target is "major", found "prepatch", will auto-merge')
+  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.4-prerelease')
+  assert.equal(core.info.getCall(7).args[0], 'all dependency updates semver:major allowed, got semver:prepatch, will auto-merge')
 
   core.info.restore()
 })

--- a/action/test/parse/pre-release.js
+++ b/action/test/parse/pre-release.js
@@ -35,3 +35,48 @@ tap.test('parse -> pre-release -> greater match', async assert => {
 
   core.info.restore()
 })
+
+tap.test('parse -> pre-release -> lesser match (premajor)', async assert => {
+  assert.plan(4)
+
+  sinon.stub(core, 'info')
+
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 7.0.0-pre.0 in /path', [], 'minor')
+
+  assert.notOk(proceed, false)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(3).args[0], 'to: 7.0.0-pre.0')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+
+  core.info.restore()
+})
+
+tap.test('parse -> pre-release -> lesser match (preminor)', async assert => {
+  assert.plan(4)
+
+  sinon.stub(core, 'info')
+
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2 to 6.2.0-pre.1 in /path', [], 'patch')
+
+  assert.notOk(proceed, false)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(3).args[0], 'to: 6.2.0-pre.1')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+
+  core.info.restore()
+})
+
+tap.test('parse -> pre-release -> actual prerelease', async assert => {
+  assert.plan(4)
+
+  sinon.stub(core, 'info')
+
+  const proceed = parse('chore(deps): bump api-problem from 6.1.2-pre.0 to 6.1.2-pre.1 in /path', [], 'patch')
+
+  assert.notOk(proceed, false)
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(3).args[0], 'to: 6.1.2-pre.1')
+  assert.equal(core.info.getCall(7).args[0], 'manual merging required')
+
+  core.info.restore()
+})


### PR DESCRIPTION
With this PR, the action now tries to determine whether a dependency is a production or development dependency and checks whether the update is security critical. 

More fine-grained merge options are now available through `.github/auto-merge.yml`, which is based on the `automerged_updates` key of the original dependabot config. If both a target and this file are given, the config file is preferred.

fixes: #7 

