### PR TITLE
Indicate early exit when not @dependabot.

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -19,7 +19,7 @@ const { payload: { sender } } = github.context // eslint-disable-line camelcase
 
 // exit early if PR is not by dependabot
 if (!sender || !['dependabot[bot]', 'dependabot-preview[bot]'].includes(sender.login)) {
-  core.warning(`expected PR by "dependabot[bot]", found "${sender ? sender.login : 'no-sender'}" instead`)
+  core.warning(`exiting early - expected PR by "dependabot[bot]", found "${sender ? sender.login : 'no-sender'}" instead`)
   process.exit(0)
 }
 


### PR DESCRIPTION
The action helpfully warns that the sender (`github.actor`) is not @dependabot. When this occurs, this log message is the only output, and it's not obvious whether the action did anything further. The enclosed patch indicates that the action is exiting early in its warning.

Thanks!