### PR TITLE
Fix workflow event in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Automatically merge Dependabot PRs when version comparison is within range.
 name: auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   auto-merge:


### PR DESCRIPTION
As per https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-859838259, the event to use on the workflow file should be `pull_request_target` instead of `pull_request`. 

This PR fixes the README example.