### PR TITLE
Add support for version constraint prefixes

### DIFF
--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -42,8 +42,8 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
   }
 
   // extract version from the title, allowing for constraints (~,^,>=) and v prefix
-  const from = title.match(new RegExp('from \D*' + regex.semver.source))?.groups
-  const to = title.match(new RegExp('to \D*' + regex.semver.source))?.groups
+  const from = title.match(new RegExp('from \\D*' + regex.semver.source))?.groups
+  const to = title.match(new RegExp('to \\D*' + regex.semver.source))?.groups
 
   if (!to) {
     core.warning('failed to parse title: no recognizable versions')


### PR DESCRIPTION
This should address #32, this is a common type of version string for Composer and NPM packages so would be great to handle.

This doesn't extend to supporting complex version constraints like `>=1.4,<2.0` for instance. I'm not sure what the best approach would be in those situations to be honest. This change as-is would at least allow a significant improvement for merging simple version constraints.