### PR TITLE
Add handling for php / composer to dependencies.js

### DIFF
--- a/action/lib/dependencies.js
+++ b/action/lib/dependencies.js
@@ -4,15 +4,28 @@ import fs from 'fs'
 import core from '@actions/core'
 
 // Look at possible package files to determine the dependency type
-// For now, this only includes npm
+// For now, this only includes npm and composer (php)
 export default function (workspace) {
-  const packageJsonPath = path.join(workspace, 'package.json')
+  const packageConfig = {
+    {
+      'path': path.join(workspace, 'package.json'),
+      'dev': 'devDependencies'
+    },
+    {
+      'path': path.join(workspace, 'composer.json'),
+      'dev': 'require-dev'
+    }
+  };
 
-  if (fs.existsSync(packageJsonPath)) {
-    try {
-      return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-    } catch (err) {
-      core.debug(err)
+  for (const { path, dev } of packageConfig) {
+    if (fs.existsSync(path)) {
+      try {
+        let config = JSON.parse(fs.readFileSync(path, 'utf8'))
+
+        return { 'devDependencies': config[dev] };
+      } catch (err) {
+        core.debug(err)
+      }
     }
   }
 }


### PR DESCRIPTION
This is just an idea how to add support for composer / php. Since I have no experience with JS, I probably did it poorly. This is the result of my quick research regarding my comment [here] (https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/102#issuecomment-1003756669). Since only npm is currently supported (something that should be better highlighted in the README), it's no wonder that this feature doesn't work for me or php / composer. This change might fix the problem.