### PR TITLE
Remove config requirement based on action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ steps:
 | input          | required | default                  | description                                         |
 |----------------|----------|--------------------------|-----------------------------------------------------|
 | `github-token` | ✔        | `github.token`           | The GitHub token used to merge the pull-request     |
-| `config`       | ✔        | `.github/auto-merge.yml` | Path to configuration file *(relative to root)*     |
+| `config`       | ❌        | `.github/auto-merge.yml` | Path to configuration file *(relative to root)*     |
 | `target`       | ❌        | `patch`                  | The version comparison target (major, minor, patch) |
 | `command`      | ❌        | `merge`                  | The command to pass to Dependabot                   |
 | `botName`      | ❌        | `dependabot`             | The bot to tag in approve/comment message.          |


### PR DESCRIPTION
Based on [`action.yml`](https://github.com/ahmadnassri/action-dependabot-auto-merge/blob/master/action.yml#L16), a config file is not required for this action to run.