### PR TITLE
clarified confusing caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Automatically merge Dependabot PRs when version comparison is within range.
 [![test][test-img]][test-url]
 [![semantic][semantic-img]][semantic-url]
 
-> **Note:** *Dependabot will wait until all your status checks pass before merging. This is a function of Dependabot itself, and not this Action.*
+> **Note:** *Dependabot will wait until all your status checks pass before merging &mdash; that is how Dependabot itself functions. The `action-dependabot-auto-merge` Action does not affect this (we cannot hurry-up the Dependabot 🤖⏳).*
 
 ## Usage
 


### PR DESCRIPTION
About the dependabot waiting...

It was confusing to me, because the word _This_ in the original text (_This is a function&hellip;_) ws ambiguous as to whether it is referring to the functionality of the Dependabot or the Action. I.e., I thought that the text was saying that it is not an Action (despite being in the GitHub Actions Marketplace), but rather a modifier on the Dependabot functionality.

The updated language avoids this potential confusion.