### PR TITLE
Fix version parsing when patch is missing

### DIFF
--- a/action/test/parse/dep-name.js
+++ b/action/test/parse/dep-name.js
@@ -36,6 +36,30 @@ tap.test('title -> in range', async assert => {
   fs.existsSync.restore()
 })
 
+tap.test('title -> non semver from 2 to 3', async assert => {
+  assert.plan(8)
+
+  sinon.stub(core, 'info')
+  sinon.stub(fs, 'existsSync').returns(false)
+
+  const options = {
+    title: 'chore(deps): bump api-problem from 6.1 to 6.1.4 in /path',
+    config: config('api-problem', 'major')
+  }
+
+  assert.ok(parse(options))
+  assert.ok(core.info.called)
+  assert.equal(core.info.getCall(0)?.firstArg, 'title: "chore(deps): bump api-problem from 6.1 to 6.1.4 in /path"')
+  assert.equal(core.info.getCall(1)?.firstArg, 'depName: api-problem')
+  assert.equal(core.info.getCall(2)?.firstArg, 'from: 6.1.0')
+  assert.equal(core.info.getCall(3)?.firstArg, 'to: 6.1.4')
+  assert.equal(core.info.getCall(6)?.firstArg, 'config: api-problem:semver:major')
+  assert.equal(core.info.getCall(7)?.firstArg, 'api-problem:semver:major detected, will auto-merge')
+
+  core.info.restore()
+  fs.existsSync.restore()
+})
+
 tap.test('title -> wildcard / regex', async assert => {
   assert.plan(8)
 


### PR DESCRIPTION
- update regex to parse version without patch part
- add version convertion to add fake `.0` as patch 