### PR TITLE
docs: explicitly tell where to create the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The GitHub token is a [Personal Access Token](https://docs.github.com/en/github/
 
 The token MUST be created from a user with **`push`** permission to the repository.
 
+Create the token in the *Repository* > `Settings` > `Secrets` > `Depandabot` section.
+
 > ℹ *see reference for [user owned repos](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/permission-levels-for-a-user-account-repository) and for [org owned repos](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization)*
 
 ### Configuration file syntax


### PR DESCRIPTION
I created the token in Actions instead of Dependabot and was not working. 

This is a solution for bug: https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/58#issuecomment-1156061443