### PR TITLE
fix: handle octokit api changes

### DIFF
--- a/action/lib/api.js
+++ b/action/lib/api.js
@@ -1,5 +1,5 @@
 export async function approve (octokit, repo, { number }, body) {
-  await octokit.pulls.createReview({
+  await octokit.rest.pulls.createReview({
     ...repo,
     pull_number: number,
     event: 'APPROVE',
@@ -8,7 +8,7 @@ export async function approve (octokit, repo, { number }, body) {
 }
 
 export async function comment (octokit, repo, { number }, body) {
-  await octokit.issues.createComment({
+  await octokit.rest.issues.createComment({
     ...repo,
     issue_number: number,
     body


### PR DESCRIPTION
## Context

Fixing a breaking change introduced in later versions of OctoKit where you need to invoke any api calls using `octokit.rest.<api method>` with the latest version.

## Resolves

- #166