### PR TITLE
Define merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ steps:
 | `target`       | ❌       | `patch`                  | The version comparison target (major, minor, patch) |
 | `command`      | ❌       | `merge`                  | The command to pass to Dependabot                   |
 | `botName`      | ❌       | `dependabot`             | The bot to tag in approve/comment message.          |
-| `approve`      | ❌       | `true`                   | Auto-approve pull-requests                          |
+| `approve`      | ❌       | `true`                   | Auto-approve pull-requests (deprecated, use `strategy`) |
+| `strategy`     | ❌       | `approve-and-merge`      | Action to perform, possible values are `approve-and-merge`, `approve-only`, `merge-only`  |
+
 
 ### Token Scope
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,11 @@ inputs:
     default: 'true'
     required: false
 
+  strategy:
+    description: Action to perform for merge
+    default: 'approve-and-merge'
+    required: false
+
   target:
     description: The version comparison target (major, minor, patch). This is ignored if .github/auto-merge.yml exists
     default: patch

--- a/action/index.js
+++ b/action/index.js
@@ -30,7 +30,8 @@ const inputs = {
   target: core.getInput('target', { required: false }),
   command: core.getInput('command', { required: false }),
   botName: core.getInput('botName', { required: false }),
-  approve: core.getInput('approve', { required: false })
+  approve: core.getInput('approve', { required: false }),
+  strategy: core.getInput('strategy', { required: false })
 }
 
 // error handler

--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -27,9 +27,16 @@ export default async function (inputs) {
   })
 
   if (proceed) {
-    const command = inputs.approve === 'true' ? approve : comment
     const botName = inputs.botName || 'dependabot'
 
-    await command(octokit, repo, pull_request, `@${botName} ${inputs.command}`)
+    if (inputs.approve === 'approve-only') {
+      await approve(octokit, repo, pull_request, ``)
+    } else if (inputs.approve === 'merge-only') {
+      await comment(octokit, repo, pull_request, `@${botName} ${inputs.command}`)
+    } else {
+      // legacy code for backward compatibility
+      const command = inputs.approve === 'true' ? approve : comment
+      await command(octokit, repo, pull_request, `@${botName} ${inputs.command}`)
+    }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,8 @@ steps:
 | `target`       | ❌        | `patch`                  | The version comparison target (major, minor, patch) |
 | `command`      | ❌        | `merge`                  | The command to pass to Dependabot                   |
 | `botName`      | ❌        | `dependabot`             | The bot to tag in approve/comment message.          |
-| `approve`      | ❌        | `true`                   | Auto-approve pull-requests                          |
+| `approve`      | ❌       | `true`                   | Auto-approve pull-requests (deprecated, use `strategy`) |
+| `strategy`     | ❌       | `approve-and-merge`      | Action to perform, possible values are `approve-and-merge`, `approve-only`, `merge-only`  |
 
 ### Token Scope
 


### PR DESCRIPTION
Add a `strategy` flag to decide how to auto-merge the PR:

- `approve-and-merge` will mimic actual default, approve the PR and comment with the merge command
- `approve-only` will only approve the PR, so that other automatic tools (such as mergify) can merge the PR when CI tests pass
- `merge-only` will mimic actual `approve: false` behavior, only post comment with the merge command without approving the PR

The default `approve-and-merge` will ensure backward compatibility with existent config files, however unexpected behavior will arise when using `strategy: approve-and-merge` together with `approve: false`, therefore when updating the config file the use of `approve` parameter is deprecated.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>