### PR TITLE
KSHT-229 Handle 'none' update_type to skip auto-merge

### DIFF
--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -108,6 +108,10 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
       core.info(`config: ${dependency_name || dependency_type}:${update_type}`)
 
       switch (true) {
+        case update_type === 'none':
+          core.info(`${dependency_name || dependency_type}:${update_type} detected, will skip auto-merge because update_type is none`)
+          return process.exit(0) // soft exit
+
         case update_type === 'in_range':
           core.warning('in_range update type not supported yet')
           return process.exit(0) // soft exit


### PR DESCRIPTION
Add a case to exit the process early when the update_type is 'none'. This prevents auto-merge attempts on dependencies with no changes, ensuring proper flow and clarity in the update process.